### PR TITLE
Fix display for git information

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -29,15 +29,15 @@ if type brew &>/dev/null; then
         # git-prompt の読み込み
         source $(brew --prefix)/etc/bash_completion.d/git-prompt.sh
 
-        # dirty state（tracked file の更新の有無と staged の状況）を表示
+        # tracked file の更新の有無(`+`)と staged の状況(`*`)を表示
         GIT_PS1_SHOWDIRTYSTATE=true
-        # stash 状態を表示
+        # stash 状態(`$`)を表示
         GIT_PS1_SHOWSTASHSTATE=true
-        # untracked file の有無を表示
+        # untracked file の有無(`%`)を表示
         GIT_PS1_SHOWUNTRACKEDFILES=true
-        # HEAD とその upstream との間の比較情報を表示
+        # HEAD とその upstream との間の比較情報(`=`, `<`, `>`)を表示
         GIT_PS1_SHOWUPSTREAM="auto"
-        # dirty state を色付けして表示
+        # 現在の状態を色付けして表示
         GIT_PS1_SHOWCOLORHINTS=true
 
         # プロンプトに Git 情報を表示

--- a/.zshrc
+++ b/.zshrc
@@ -41,7 +41,7 @@ if type brew &>/dev/null; then
         GIT_PS1_SHOWCOLORHINTS=true
 
         # プロンプトに Git 情報を表示
-        export PS1='${fg[green]}%n@%m${reset_color}:${fg[blue]}%~${reset_color} ${fg[red]}$(__git_ps1 "(%s)")${reset_color}
+        export PS1='${fg[green]}%n@%m${reset_color}:${fg[blue]}%~${reset_color}$(__git_ps1 " (%s)")
 %# '
     fi
 fi


### PR DESCRIPTION
`git-prompt.sh` を更新したら git 情報の色周りが壊れてしまったので修正しました

## 詳細

- `git-prompt.sh` が以下のように更新
  - `GIT_PS1_SHOWCOLORHINTS` の設定がうまく反映されていなかった？のが修正された
  - `GIT_PS1_SHOWCOLORHINTS` が設定されていると、`GIT_PS1_SHOWDIRTYSTATE` などの情報に色がつくものだった
    - このことに前田は気付いていなかった
- 更新されたことで設定が反映され、色周りがおかしくなっていた
